### PR TITLE
Improving docs to list options for some of the settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,20 +63,20 @@ $ yarn add evo-calendar
 
 ### :hammer_and_wrench: Settings
 
-Option | Type | Default | Description
------- | ---- | ------- | -----------
-theme | string | null | Define calendar's theme
-format | string | 'mm/dd/yyyy' | Date format
-titleFormat | string | 'MM yyyy' | Date format for calendar title
-eventHeaderFormat | string | 'MM d, yyyy' | Date format for calendar event's title
-firstDayOfWeek | string | 'Sun' | Displayed first day of the week
-language | string | 'en' | Calendar's language
-todayHighlight | boolean | false | Highlight today's date in calendar
-sidebarDisplayDefault | boolean | true | Set default visibility of sidebar
-sidebarToggler | boolean | true | Display the button for toggling the sidebar
-eventDisplayDefault | boolean | true | Set default visibility of event lists
-eventListToggler | boolean | true | Display the button for toggling the event lists
-calendarEvents | array | null | Defined events for calendar to show
+Option | Type | Default | Description | Options
+------ | ---- | ------- | ----------- | -------
+theme | string | Default | Define calendar's theme | Default, Midnight Blue, Orange Coral, Royal Navy
+format | string | 'mm/dd/yyyy' | Date format |
+titleFormat | string | 'MM yyyy' | Date format for calendar title |
+eventHeaderFormat | string | 'MM d, yyyy' | Date format for calendar event's title |
+firstDayOfWeek | number | 0 | Displayed first day of the week | 0 (Sunday) - 6 (Saturday)
+language | string | 'en' | Calendar's language | en, es, de, pt
+todayHighlight | boolean | false | Highlight today's date in calendar |
+sidebarDisplayDefault | boolean | true | Set default visibility of sidebar |
+sidebarToggler | boolean | true | Display the button for toggling the sidebar |
+eventDisplayDefault | boolean | true | Set default visibility of event lists |
+eventListToggler | boolean | true | Display the button for toggling the event lists |
+calendarEvents | array | null | Defined events for calendar to show |
 
 #### _calendarEvent_ Options Example
 ```js

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" type="text/css" href="./evo-calendar/css/evo-calendar.orange-coral.min.css">
     <link rel="stylesheet" type="text/css" href="./evo-calendar/css/evo-calendar.midnight-blue.min.css">
     <link rel="stylesheet" type="text/css" href="./evo-calendar/css/evo-calendar.royal-navy.min.css">
-    
+
     <link rel="stylesheet" type="text/css" href="demo.css">
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
@@ -67,7 +67,7 @@
                     </div>
                 </div>
             </section>
-        
+
             <section id="themes">
                 <div class="section-content">
                     <p class="section-title --shrt">themes</p>
@@ -86,7 +86,7 @@ $(<span class="red">'#calendar'</span>).<span class="yellow">evoCalendar</span>(
                                     </div>
                                 </div>
                             </div>
-                            
+
                             <div class="theme-content">
                                 <div class="console-log">
                                     <div class="log-content">
@@ -100,7 +100,7 @@ $(<span class="red">'#calendar'</span>).<span class="yellow">evoCalendar</span>(
                                     </div>
                                 </div>
                             </div>
-                        
+
                             <div class="theme-content">
                                 <div class="console-log">
                                     <div class="log-content">
@@ -114,7 +114,7 @@ $(<span class="red">'#calendar'</span>).<span class="yellow">evoCalendar</span>(
                                     </div>
                                 </div>
                             </div>
-                        
+
                             <div class="theme-content">
                                 <div class="console-log">
                                     <div class="log-content">
@@ -152,7 +152,7 @@ $(<span class="red">'#calendar'</span>).<span class="yellow">evoCalendar</span>(
                     </div>
                 </div>
             </section>
-    
+
             <section id="usage">
                 <div class="section-content">
                     <p class="section-title --lng">let the coding begins!</p>
@@ -214,7 +214,7 @@ $(<span class="blue">document</span>).<span class="yellow">ready</span>(<span cl
         <span class="red">&lt;link <span class="blue">rel</span><span class="white">=</span><span class="yellow">"stylesheet"</span> <span class="blue">type</span><span class="white">=</span><span class="yellow">"text/css"</span> <span class="blue">href</span><span class="white">=</span><span class="yellow">"css/evo-calendar.midnight-blue.css"</span>/&gt;</span>
     <span class="red">&lt;/head&gt;</span>
     <span class="red">&lt;body&gt;</span>
-        
+
         <span class="green">// this is where your calendar goes.. :)</span>
         <span class="red">&lt;div <span class="blue">id</span><span class="white">=</span><span class="yellow">"calendar"</span>&gt;&lt;/div&gt;</span>
 
@@ -255,14 +255,14 @@ $(<span class="blue">document</span>).<span class="yellow">ready</span>(<span cl
                                 <tr data-settings="theme">
                                     <td>theme</td>
                                     <td>string</td>
-                                    <td class="gray">null</td>
-                                    <td>Define calendar's theme</td>
+                                    <td class="gray">Default</td>
+                                    <td>Define calendar's theme <br> Options: Default, Midnight Blue, Orange Coral, Royal Navy</td>
                                 </tr>
                                 <tr data-settings="language">
                                     <td>language</td>
                                     <td>string</td>
                                     <td class="red">'en'</td>
-                                    <td>Calendar's language</td>
+                                    <td>Calendar's language <br> Options: en, es, de, pt</td>
                                 </tr>
                                 <tr data-settings="format">
                                     <td>format</td>
@@ -286,7 +286,7 @@ $(<span class="blue">document</span>).<span class="yellow">ready</span>(<span cl
                                     <td>firstDayOfWeek</td>
                                     <td>number</td>
                                     <td class="violet">0</td>
-                                    <td>Displayed first day of the week</td>
+                                    <td>Displayed first day of the week <br>Options: 0 (Sunday) - 6 (Saturday)</td>
                                 </tr>
                                 <tr data-settings="todayHighlight">
                                     <td>todayHighlight</td>


### PR DESCRIPTION
Some of the settings as themes and languages have options that are not being listed in the documentation. In this PR I'm adding them to README and also to the demo page. On the page it looks like:

![image](https://user-images.githubusercontent.com/846063/85941806-91c30280-b8fb-11ea-8472-4fa929627666.png)

On README looks like:

![image](https://user-images.githubusercontent.com/846063/85941889-29c0ec00-b8fc-11ea-89b4-12f708a1954c.png)


If you believe they should be presented in another form, let me know and I can adjust them. :)