### PR TITLE
meta viewport for responsive

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Then, before your closing ```<body>``` tag add:
 
 In your html file:
 ```html
+<head>
+  <!-- needed to ensure the CSS rules for responsive design work correctly -->
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+
 <div id="calendar"></div>
 ```
 


### PR DESCRIPTION
I spent hours trying to understand why the responsive was not working on mobiles

This line is needed to ensure the CSS rules for responsive design work correctly by setting the viewport width to match the device's screen width